### PR TITLE
Replace `fregante/setup-git-token` with `setup-git-user`

### DIFF
--- a/.github/workflows/ca-gov.yml
+++ b/.github/workflows/ca-gov.yml
@@ -14,9 +14,7 @@ jobs:
    steps:
     - uses: actions/checkout@v2
        #set up username and id 
-    - uses: fregante/setup-git-token@v1
-      with:
-         token: ${{ secrets.GITHUB_TOKEN }}
+    - uses: fregante/setup-git-user@v1
     - name: pull data via curl
       run: |
        git remote add github "https://$GITHUB_ACTOR:$GITHUB_TOKEN@github.com/$GITHUB_REPOSITORY.git"

--- a/.github/workflows/co-knox.yml
+++ b/.github/workflows/co-knox.yml
@@ -16,9 +16,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
        #set up username and id 
-    - uses: fregante/setup-git-token@v1
-      with:
-         token: ${{ secrets.GITHUB_TOKEN }}
+    - uses: fregante/setup-git-user@v1
     - name: Set up Python
       uses: actions/setup-python@v1
       with:

--- a/.github/workflows/covid-tracking-state.yml
+++ b/.github/workflows/covid-tracking-state.yml
@@ -16,9 +16,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
        #set up username and id 
-    - uses: fregante/setup-git-token@v1
-      with:
-         token: ${{ secrets.GITHUB_TOKEN }}
+    - uses: fregante/setup-git-user@v1
     - name: pull data via curl
       run: |
        git remote add github "https://$GITHUB_ACTOR:$GITHUB_TOKEN@github.com/$GITHUB_REPOSITORY.git"

--- a/.github/workflows/ny-doh.yml
+++ b/.github/workflows/ny-doh.yml
@@ -16,9 +16,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
        #set up username and id 
-    - uses: fregante/setup-git-token@v1
-      with:
-         token: ${{ secrets.GITHUB_TOKEN }}
+    - uses: fregante/setup-git-user@v1
     - name: pull data via curl
       run: |
        git remote add github "https://$GITHUB_ACTOR:$GITHUB_TOKEN@github.com/$GITHUB_REPOSITORY.git"

--- a/.github/workflows/oh-doh.yml
+++ b/.github/workflows/oh-doh.yml
@@ -15,9 +15,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
        #set up username and id 
-    - uses: fregante/setup-git-token@v1
-      with:
-         token: ${{ secrets.GITHUB_TOKEN }}
+    - uses: fregante/setup-git-user@v1
     - name: pull data via curl
       run: |
           git remote add github "https://$GITHUB_ACTOR:$GITHUB_TOKEN@github.com/$GITHUB_REPOSITORY.git"

--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -17,9 +17,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
        #set up username and id 
-    - uses: fregante/setup-git-token@v1
-      with:
-         token: ${{ secrets.GITHUB_TOKEN }}
+    - uses: fregante/setup-git-user@v1
     - name: Set up Python
       uses: actions/setup-python@v1
       with:

--- a/.github/workflows/stats-can.yml
+++ b/.github/workflows/stats-can.yml
@@ -17,9 +17,7 @@ jobs:
    steps:
     - uses: actions/checkout@v2
        #set up username and id 
-    - uses: fregante/setup-git-token@v1
-      with:
-         token: ${{ secrets.GITHUB_TOKEN }}
+    - uses: fregante/setup-git-user@v1
     - name: pull data via curl
       run: |
        apt-get update && apt-get install -y zip

--- a/.github/workflows/tn-doh.yml
+++ b/.github/workflows/tn-doh.yml
@@ -16,9 +16,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
        #set up username and id 
-    - uses: fregante/setup-git-token@v1
-      with:
-         token: ${{ secrets.GITHUB_TOKEN }}
+    - uses: fregante/setup-git-user@v1
     - name: Set up Python
       uses: actions/setup-python@v1
       with:

--- a/.github/workflows/tn-edu.yml
+++ b/.github/workflows/tn-edu.yml
@@ -20,9 +20,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
        #set up username and id 
-    - uses: fregante/setup-git-token@v1
-      with:
-         token: ${{ secrets.GITHUB_TOKEN }}
+    - uses: fregante/setup-git-user@v1
     - name: Set up Python
       uses: actions/setup-python@v1
       with:


### PR DESCRIPTION
In the v2 of `actions/checkout`, setting the token is no longer necessary, so I created a new config-less action to just set the git user: https://github.com/fregante/setup-git-user